### PR TITLE
Added checking 'scm.commit' before pushing scm payloads to field

### DIFF
--- a/src/hubot-jenkins-slack.coffee
+++ b/src/hubot-jenkins-slack.coffee
@@ -104,7 +104,7 @@ module.exports = (robot) ->
             title: "URL"
             value: params.ghprbPullLink
             short: true
-        else
+        else if data.build.scm.commit
           payload.content.fields.push
             title: "Commit SHA1"
             value: data.build.scm.commit


### PR DESCRIPTION
This is for cases when jobs do not containt scm stuffs, I dont want to see a blank "Commit SHA1" & "Branch"
